### PR TITLE
pointing to the wrong actions

### DIFF
--- a/.github/workflows/roadmap-milestones.yml
+++ b/.github/workflows/roadmap-milestones.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for old milestones
-        uses: conduitio/project_automation_testing/actions/check_for_old_milestones@main
+        uses: conduitio/automation/actions/check_for_old_milestones@main
         id: milestone_check
         with:
-          org-repo: "conduitio/project_automation_testing"
+          org-repo: ${{ inputs.org-repo }}
           repo-token: ${{ secrets.project-automation-token }}
 
       - name: Echo the found milestone
@@ -34,7 +34,7 @@ jobs:
 
       - name: Manage Milestones
         if: ${{ steps.milestone_check.outputs.found == 'true' }}
-        uses: conduitio/project_automation_testing/actions/manage_milestones@main
+        uses: conduitio/automation/actions/manage_milestones@main
         with:
           project-node-id: ${{ inputs.project }}
           org-repo: ${{ inputs.org-repo }}


### PR DESCRIPTION
The managing milestone workflow was pointing to a private action in a testing repo. Needed to point to the automation repo.